### PR TITLE
Fix Backoff Strategy for 429 Too Many Requests (Rate limit error)

### DIFF
--- a/tests/configuration/fixtures.py
+++ b/tests/configuration/fixtures.py
@@ -4,6 +4,6 @@ from tap_mixpanel.client import MixpanelClient
 
 @pytest.fixture
 def mixpanel_client():
-    mixpanel_client = MixpanelClient('API_SECRET')
+    mixpanel_client = MixpanelClient('API_SECRET', 'username', 'password', 'project_id')
     mixpanel_client._MixpanelClient__verified = True
     return mixpanel_client

--- a/tests/unittests/test_medium_client.py
+++ b/tests/unittests/test_medium_client.py
@@ -1,19 +1,13 @@
-import unittest
 from collections.abc import Generator
 from unittest import mock
-from unittest.mock import Mock, PropertyMock, patch
 
-import backoff
 import requests
 import requests_mock
-import urllib3
-from requests import Session
-from urllib3 import Timeout
 
 import pytest
 from pytest import raises
-from tap_mixpanel import MixpanelClient, client
-from tap_mixpanel.client import ReadTimeoutError, Server5xxError
+from tap_mixpanel import client
+from tap_mixpanel.client import ReadTimeoutError, Server5xxError, MixpanelRateLimitsError
 from tests.configuration.fixtures import mixpanel_client
 
 
@@ -29,17 +23,25 @@ def test_request_export_backoff_on_timeout(mock_sleep, mixpanel_client):
         assert mock_sleep.call_count == client.BACKOFF_MAX_TRIES_REQUEST - 1
 
 
+@pytest.mark.parametrize(
+    'status_code,exception,response_json,backoff_retry_count',
+    [
+        pytest.param(504, Server5xxError, None, client.BACKOFF_MAX_TRIES_REQUEST - 1, id="Server5xxError"),
+        pytest.param(429, MixpanelRateLimitsError, {'error': 'Too Many Requests', 'status': 429}, 6, id="MixpanelRateLimitsError"),
+    ],
+)
 @mock.patch('time.sleep', return_value=None)
-def test_request_export_backoff_on_remote_timeout(mock_sleep, mixpanel_client):
+def test_request_export_backoff_on_remote_timeout(mock_sleep, mixpanel_client, status_code, exception, response_json,
+                                                  backoff_retry_count):
     with requests_mock.Mocker() as m:
-        m.request('GET', 'http://test.com', text=None, status_code=504)
+        m.request('GET', 'http://test.com', content=None, json=response_json, status_code=status_code)
         result = mixpanel_client.request_export('GET', url='http://test.com')
 
-        with raises(Server5xxError) as ex:
+        with raises(exception) as ex:
             for record in result:
                 pass
         # Assert backoff retry count as expected    
-        assert mock_sleep.call_count == client.BACKOFF_MAX_TRIES_REQUEST - 1
+        assert mock_sleep.call_count == backoff_retry_count
 
 @mock.patch('time.sleep', return_value=None)
 def test_request_backoff_on_timeout(mock_sleep, mixpanel_client):

--- a/tests/unittests/test_medium_client.py
+++ b/tests/unittests/test_medium_client.py
@@ -24,15 +24,14 @@ def test_request_export_backoff_on_timeout(mock_sleep, mixpanel_client):
 
 
 @pytest.mark.parametrize(
-    'status_code,exception,response_json,backoff_retry_count',
+    'status_code,exception,response_json',
     [
-        pytest.param(504, Server5xxError, None, client.BACKOFF_MAX_TRIES_REQUEST - 1, id="Server5xxError"),
-        pytest.param(429, MixpanelRateLimitsError, {'error': 'Too Many Requests', 'status': 429}, 6, id="MixpanelRateLimitsError"),
+        pytest.param(504, Server5xxError, None, id="Server5xxError"),
+        pytest.param(429, MixpanelRateLimitsError, {'error': 'Too Many Requests', 'status': 429}, id="MixpanelRateLimitsError"),
     ],
 )
 @mock.patch('time.sleep', return_value=None)
-def test_request_export_backoff_on_remote_timeout(mock_sleep, mixpanel_client, status_code, exception, response_json,
-                                                  backoff_retry_count):
+def test_request_export_backoff_on_remote_timeout(mock_sleep, mixpanel_client, status_code, exception, response_json):
     with requests_mock.Mocker() as m:
         m.request('GET', 'http://test.com', content=None, json=response_json, status_code=status_code)
         result = mixpanel_client.request_export('GET', url='http://test.com')
@@ -41,7 +40,7 @@ def test_request_export_backoff_on_remote_timeout(mock_sleep, mixpanel_client, s
             for record in result:
                 pass
         # Assert backoff retry count as expected    
-        assert mock_sleep.call_count == backoff_retry_count
+        assert mock_sleep.call_count == client.BACKOFF_MAX_TRIES_REQUEST - 1
 
 @mock.patch('time.sleep', return_value=None)
 def test_request_backoff_on_timeout(mock_sleep, mixpanel_client):

--- a/tests/unittests/test_medium_client.py
+++ b/tests/unittests/test_medium_client.py
@@ -33,7 +33,7 @@ def test_request_export_backoff_on_timeout(mock_sleep, mixpanel_client):
 @mock.patch('time.sleep', return_value=None)
 def test_request_export_backoff_on_remote_timeout(mock_sleep, mixpanel_client, status_code, exception, response_json):
     with requests_mock.Mocker() as m:
-        m.request('GET', 'http://test.com', content=None, json=response_json, status_code=status_code)
+        m.request('GET', 'http://test.com', text=None, json=response_json, status_code=status_code)
         result = mixpanel_client.request_export('GET', url='http://test.com')
 
         with raises(exception) as ex:


### PR DESCRIPTION
## Problem

The error 429 (too many requests, rate limit error) was being ignored and re-raised the first time it was showing up. The exception custom class (that the backoff was expecting) was created but was never used since it was not included in the `ERROR_CODE_EXCEPTION_MAPPING` or manually raised.

## Proposed changes

So we included the exception in the backoff strategy to retry in case this exception is raised.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions