### PR TITLE
Fix: Avoid write empty state

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-mixpanel',
-      version='1.2.17',
+      version='1.2.18',
       description='Singer.io tap for extracting data from the mixpanel API - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -511,8 +511,6 @@ def update_currently_syncing(state, stream_name):
         del state['currently_syncing']
     else:
         singer.set_currently_syncing(state, stream_name)
-    if state:
-        singer.write_state(state)
 
 
 def sync(client, config, catalog, state, start_date):

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -48,7 +48,8 @@ def write_bookmark(state, stream, value):
         state['bookmarks'] = {}
     state['bookmarks'][stream] = value
     LOGGER.info('Write state for stream: {}, value: {}'.format(stream, value))
-    singer.write_state(state)
+    if state:
+        singer.write_state(state)
 
 
 def transform_datetime(this_dttm):
@@ -510,7 +511,8 @@ def update_currently_syncing(state, stream_name):
         del state['currently_syncing']
     else:
         singer.set_currently_syncing(state, stream_name)
-    singer.write_state(state)
+    if state:
+        singer.write_state(state)
 
 
 def sync(client, config, catalog, state, start_date):

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -509,7 +509,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
 def update_currently_syncing(state, stream_name):
     if (stream_name is None) and ('currently_syncing' in state):
         del state['currently_syncing']
-        singer.write_state(state)
     else:
         singer.set_currently_syncing(state, stream_name)
     if state:

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -48,7 +48,11 @@ def write_bookmark(state, stream, value):
         state['bookmarks'] = {}
     state['bookmarks'][stream] = value
     LOGGER.info('Write state for stream: {}, value: {}'.format(stream, value))
-    if state:
+    write_state(state)
+
+def write_state(state):
+    if state and 'bookmarks' in state:
+        # Only write state if it is not empty.
         singer.write_state(state)
 
 
@@ -511,8 +515,7 @@ def update_currently_syncing(state, stream_name):
         del state['currently_syncing']
     else:
         singer.set_currently_syncing(state, stream_name)
-    if state:
-        singer.write_state(state)
+    write_state(state)
 
 
 def sync(client, config, catalog, state, start_date):

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -509,6 +509,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
 def update_currently_syncing(state, stream_name):
     if (stream_name is None) and ('currently_syncing' in state):
         del state['currently_syncing']
+        singer.write_state(state)
     else:
         singer.set_currently_syncing(state, stream_name)
     if state:

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -51,7 +51,7 @@ def write_bookmark(state, stream, value):
     write_state(state)
 
 def write_state(state):
-    if state and 'bookmarks' in state:
+    if state:
         # Only write state if it is not empty.
         singer.write_state(state)
 

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -511,6 +511,8 @@ def update_currently_syncing(state, stream_name):
         del state['currently_syncing']
     else:
         singer.set_currently_syncing(state, stream_name)
+    if state:
+        singer.write_state(state)
 
 
 def sync(client, config, catalog, state, start_date):


### PR DESCRIPTION
## Problem
https://github.com/meltano/sdk/pull/2844

## Proposed changes

As this extractor doesn't use the Meltano singer SDK, this https://github.com/meltano/sdk/pull/2844 will not work as the states are manually written.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions